### PR TITLE
修复 ciu-embed-iframe 初始化样式设置错误和调整特性容器边框宽度

### DIFF
--- a/src/scripts/embed.ts
+++ b/src/scripts/embed.ts
@@ -5,7 +5,7 @@
   const [ft, p, f, t, m, obs] = ['feature', 'past', 'future', 'theme', 'meta', 'observer']
   const [qs, vercel, peng, protocol] = ['script[src*="caniuse"][src*="/embed.js"]', 'caniuse-embed.vercel.app', 'caniuse.pengzhanbo.cn', 'https://']
   const [ce, cei] = ['.ciu-embed', 'ciu-embed-iframe']
-  const style = ['style', 'display:block;width:100%;height:330px;border:none;'] as const
+  const style = ['style', 'display:block;width:100%;height:330px;border:none;border-radius:0;'] as const
 
   /**
    * 对于国内的用户，使用 caniuse.pengzhanbo.cn 作为替代，解决 vercel.app 网站无法访问的问题
@@ -89,7 +89,7 @@
     const iframe = document.createElement('iframe') as HTMLIFrameElement
     iframe.src = source
     iframe.className = cei
-    attr(iframe, ...style)
+    iframe.style.cssText = style[1]
     iframe.allow = 'fullscreen'
     embed.appendChild(iframe)
     return iframe

--- a/src/styles/feature.css
+++ b/src/styles/feature.css
@@ -144,7 +144,7 @@
 .feature {
   background-color: var(--primary-bg);
   position: relative;
-  border: 1px solid var(--primary-border);
+  border: 3px solid var(--primary-border);
   border-bottom: 0;
   transition: var(--transition);
 }


### PR DESCRIPTION
解决 #1 

调整前
<img width="1170" alt="image" src="https://github.com/pengzhanbo/caniuse-embed/assets/33419593/63188661-14c3-4361-b533-2f308a4f19b5">
调整后
<img width="1151" alt="image" src="https://github.com/pengzhanbo/caniuse-embed/assets/33419593/eebd00e4-0629-476a-91fa-e3e8cda33dcd">
